### PR TITLE
fix disabled transformselect init not working when _touch is true

### DIFF
--- a/dev/jquery.fancyform.js
+++ b/dev/jquery.fancyform.js
@@ -392,11 +392,6 @@
 						$inp = $ul.find("input");
                     t.after($ul);
 
-                    // Bind handlers
-                    if (t.is(":disabled")) {
-                        method.disabled.call(_this, 1);
-                    }
-
                     if (_this.type == "select-multiple" && !_touch) {
                         if (t.attr("name") && t.attr("name").indexOf("_backup") == -1) {
                             t.attr("name", t.attr("name") + "_backup");
@@ -489,6 +484,11 @@
                             position: "relative"
                         });
                         t.change(method.mobileChange);
+                    }
+
+                    // Bind handlers
+                    if (t.is(":disabled")) {
+                        method.disabled.call(_this, 1);
                     }
                 },
                 getUL: function () {


### PR DESCRIPTION
When disabled select init transformselect if _touch is true , disabled method is not working.
Because getUL method would get closest ul, but this action should be after select DOM appendTo ul.